### PR TITLE
Use Bash's built-in function to convert the filename to lowercase

### DIFF
--- a/extract.sh
+++ b/extract.sh
@@ -8,16 +8,12 @@ function extract {
  else
     if [ -f "$1" ] ; then
         case "${1,,}" in
-          *.tar.bz2)   tar xvjf ./"$1"    ;;
-          *.tar.gz)    tar xvzf ./"$1"    ;;
-          *.tar.xz)    tar xvJf ./"$1"    ;;
+          *.tar.bz2|*.tar.gz|*.tar.xz|*.tbz2|*.tgz|*.txz|*.tar) 
+                       tar xvf "$1"       ;;
           *.lzma)      unlzma ./"$1"      ;;
           *.bz2)       bunzip2 ./"$1"     ;;
           *.rar)       unrar x -ad ./"$1" ;;
           *.gz)        gunzip ./"$1"      ;;
-          *.tar)       tar xvf ./"$1"     ;;
-          *.tbz2)      tar xvjf ./"$1"    ;;
-          *.tgz)       tar xvzf ./"$1"    ;;
           *.zip)       unzip ./"$1"       ;;
           *.z)         uncompress ./"$1"  ;;
           *.7z)        7z x ./"$1"        ;;

--- a/extract.sh
+++ b/extract.sh
@@ -7,8 +7,7 @@ function extract {
     echo "Usage: extract <path/file_name>.<zip|rar|bz2|gz|tar|tbz2|tgz|Z|7z|xz|ex|tar.bz2|tar.gz|tar.xz>"
  else
     if [ -f "$1" ] ; then
-        local nameInLowerCase=`echo "$1" | awk '{print tolower($0)}'`
-        case "$nameInLowerCase" in
+        case "${1,,}" in
           *.tar.bz2)   tar xvjf ./"$1"    ;;
           *.tar.gz)    tar xvzf ./"$1"    ;;
           *.tar.xz)    tar xvJf ./"$1"    ;;

--- a/extract.sh
+++ b/extract.sh
@@ -20,7 +20,7 @@ function extract {
           *.tbz2)      tar xvjf ./"$1"    ;;
           *.tgz)       tar xvzf ./"$1"    ;;
           *.zip)       unzip ./"$1"       ;;
-          *.Z)         uncompress ./"$1"  ;;
+          *.z)         uncompress ./"$1"  ;;
           *.7z)        7z x ./"$1"        ;;
           *.xz)        unxz ./"$1"        ;;
           *.exe)       cabextract ./"$1"  ;;

--- a/extract.sh
+++ b/extract.sh
@@ -5,6 +5,7 @@ function extract {
  if [ -z "$1" ]; then
     # display usage if no parameters given
     echo "Usage: extract <path/file_name>.<zip|rar|bz2|gz|tar|tbz2|tgz|Z|7z|xz|ex|tar.bz2|tar.gz|tar.xz>"
+    return 1
  else
     if [ -f "$1" ] ; then
         case "${1,,}" in
@@ -19,10 +20,14 @@ function extract {
           *.7z)        7z x ./"$1"        ;;
           *.xz)        unxz ./"$1"        ;;
           *.exe)       cabextract ./"$1"  ;;
-          *)           echo "extract: '$1' - unknown archive method" ;;
+          *)
+                       echo "extract: '$1' - unknown archive method"
+                       return 1
+                       ;;
         esac
     else
         echo "'$1' - file does not exist"
+        return 1
     fi
 fi
 }


### PR DESCRIPTION
Some code refactoring, descriptions of each of my pull request commits:

1. Incorporates reox's fix for ".z" as the current case statement will not ever trigger for an uppercase ".Z" since the filename has been converted to lowercase
2. Use bash's built-in function which is more elegant than assigning a local variable and echoing a string to awk. Also, it's faster as we don't have to use a separate program, although on modern systems it's not very noticeable
3. `tar` doesn't require specifying a tarball's compression (-j,-z,-J flags). We can roll all those case statements into a unified one, reducing the script's size
4. Since this function has some built-in fail cases, a non-zero return value should be specified so any scripts sourcing and calling extract() can see if it fails