### PR TITLE
Fix lowercase conversion

### DIFF
--- a/extract.sh
+++ b/extract.sh
@@ -13,7 +13,7 @@ function extract {
     for n in "$@"
     do
       if [ -f "$n" ] ; then
-          case "${n%,}" in
+          case "${n,,}" in
             *.cbt|*.tar.bz2|*.tar.gz|*.tar.xz|*.tbz2|*.tgz|*.txz|*.tar) 
                          tar xvf "$n"       ;;
             *.lzma)      unlzma ./"$n"      ;;


### PR DESCRIPTION
Convert to lowercase instead of removing a trailing comma.
This reverts https://github.com/xvoland/Extract/commit/60f9ac56f774d9db04e8989e35a881c700ec96a9.