### PR TITLE
fix globbing

### DIFF
--- a/extract.sh
+++ b/extract.sh
@@ -33,7 +33,7 @@ function extract {
             return 1
         fi
 
-        case "${n##*.}" in
+        case "$n" in
           *.cbt|*.tar.bz2|*.tar.gz|*.tar.xz|*.tbz2|*.tgz|*.txz|*.tar)
                        tar xvf -p "$n"    ;;
           *.lzma)      unlzma ./"$n"      ;;


### PR DESCRIPTION
The variable munging turns `filename.tar.gz` into just `gz` before trying to match against `*.tar.gz`, which inevitably fails.

Removing the munging ought to fix this.